### PR TITLE
[BUGFIX] Prevent some 'undefined array key' warnings with php 8

### DIFF
--- a/Classes/Domain/Model/Dto/Table.php
+++ b/Classes/Domain/Model/Dto/Table.php
@@ -50,12 +50,12 @@ class Table
         $this->title = $tcaCtrl['title'];
         $this->titleField = $tcaCtrl['label'];
         $this->deletedField = isset($tcaCtrl['delete']) ? $tcaCtrl['delete'] : '';
-        $this->titleLabel = $GLOBALS['TCA'][$tableName]['columns'][$this->titleField]['label'];
-        $this->gdprRestrictionField = $tcaCtrl['gdpr']['restriction_field'] ?: '';
-        $this->gdprRandomizedField = $tcaCtrl['gdpr']['randomized_field'] ?: '';
-        $this->gdprRandomizeMapping = $tcaCtrl['gdpr']['randomize_mapping'] ?: [];
-        $this->gdprRandomizedDateField = $tcaCtrl['gdpr']['randomize_datefield'] ?: '';
-        $this->gdprExpirePeriod = $tcaCtrl['gdpr']['randomize_expirePeriod'] ?: 365;
+        $this->titleLabel = $GLOBALS['TCA'][$tableName]['columns'][$this->titleField]['label'] ?? '';
+        $this->gdprRestrictionField = $tcaCtrl['gdpr']['restriction_field'] ?? '';
+        $this->gdprRandomizedField = $tcaCtrl['gdpr']['randomized_field'] ?? '';
+        $this->gdprRandomizeMapping = $tcaCtrl['gdpr']['randomize_mapping'] ?? [];
+        $this->gdprRandomizedDateField = $tcaCtrl['gdpr']['randomize_datefield'] ?? '';
+        $this->gdprExpirePeriod = $tcaCtrl['gdpr']['randomize_expirePeriod'] ?? 365;
     }
 
     /**

--- a/Classes/Domain/Repository/RecordRepository.php
+++ b/Classes/Domain/Repository/RecordRepository.php
@@ -60,8 +60,8 @@ class RecordRepository extends BaseRepository
             ->fetchAll();
 
         return [
-            'restricted' => (int)$rows[1]['count'],
-            'public' => (int)$rows[0]['count']
+            'restricted' => (int) ($rows[1]['count'] ?? 0),
+            'public' => (int) ($rows[0]['count'] ?? 0)
         ];
     }
 

--- a/Classes/Service/TableInformation.php
+++ b/Classes/Service/TableInformation.php
@@ -9,6 +9,7 @@ class TableInformation
     public static function isTableEnabled(string $table): bool
     {
         if (isset($GLOBALS['TCA'][$table])
+            && !empty($GLOBALS['TCA'][$table]['ctrl']['gdpr'])
             && is_array($GLOBALS['TCA'][$table]['ctrl']['gdpr'])
             && $GLOBALS['TCA'][$table]['ctrl']['gdpr']['enabled']) {
             return true;


### PR DESCRIPTION
In TYPO11 with PHP 8 there are some errors like *PHP Warning: Undefined array key ...*.
This PR adds some additional checks (null coalescing operator's) to prevents this errors.